### PR TITLE
Feature/webhook subscribe

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
     "pydantic"
 ]
 
- # to allow a optional AWS Lambda deployment
+ # to allow an optional AWS Lambda deployment
  # package
 [project.optional-dependencies]
 aws_lambda = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,10 +72,11 @@ omit = [
 
 [tool.coverage.report]
 exclude_lines = [
-    "^/s*/././."
+    "^/s*/././.",
+    "handler = Mangum(subscribe_app)"
 ]
 exclude_also = [
-    "if __name__ == .__main__."
+    "if __name__ == .__main__.",
 ]
 
 [tool.tox]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,17 @@ license = "Apache-2.0"
 dependencies = [
     "dynaconf",
     "pymongo",
-    "httpx"
+    "httpx",
+    "uvicorn",
+    "fastapi",
+    "pydantic"
+]
+
+ # to allow a optional AWS Lambda deployment
+ # package
+[project.optional-dependencies]
+aws_lambda = [
+    "mangum"
 ]
 
 [dependency-groups]

--- a/src/app/app.py
+++ b/src/app/app.py
@@ -1,72 +1,24 @@
 """Main application module."""
 
 import logging
-from typing import TypeVar
 
-import httpx
-
-from app.config import settings
-from app.conn import Mongo_Conn
-
-API_KEY = settings.hevy_api.key
-BASE_URL = f"{settings.hevy_api.url}/{settings.hevy_api.version}"
+from app.db.conn import MongoConnection
+from app.db.data import HevyApiRepository
 
 _log = logging.getLogger(__name__)
-client = httpx.AsyncClient(base_url=BASE_URL, headers={"api-key": API_KEY})
 
-# JSONType is a recursive type hint for JSON-compatible data structures
-JSONType = TypeVar("None | bool | int | float | str | tuple | list | dict | JSONType")
+_hevy_api_repo = HevyApiRepository()
 
-
-# pull workouts with pagination
 async def pull_all_workouts(page_size: int = 5):
-    """Pull all workout data with pagination.
+    workouts = await _hevy_api_repo.pull_all_workouts(page_size=page_size)
+    await truncate_and_store_workouts(workouts)
 
-    :param page_size: The number of workouts to pull per page.
-    """
-    workout_data = []
-    # page field is 1 indexed per:
-    # - https://api.hevyapp.com/docs/#/Workouts/PaginatedWorkoutEvents
-    current_page = 1
-
-    _log.info("Pulling all workouts with a page_size of %d", page_size)
-    # pull pages until len(pages) equils page_count field of json response
-    while True:
-        try:
-            data = await _pull_workouts_page(current_page, page_size)
-        except httpx.HTTPError as e:
-            _log.error("Error pulling workouts: %s", e)
-            raise e
-        workouts = data.get("workouts", [])
-        workout_data.extend(workouts)
-        current_page += 1
-        # cover pagination cases
-        # - the events array is smaller than the page size
-        # - current_page is equal to page_count
-        if len(workouts) < page_size or data.get("page_count", 0) < data.get("page", 0):
-            break
-    _log.info("Finished pulling workouts at %d pages", current_page)
-    await truncate_and_store_workouts(workout_data)
-
-
-async def _pull_workouts_page(page: int, page_size: int) -> dict[JSONType]:
-    """Pull a single page of workout data.
-
-    :param page: The page number to pull.
-    :param page_size: The number of workouts to pull per page.
-    :return: The JSON response from the API.
-    """
-    response = await client.get("/workouts", params={"page": page, "pageSize": page_size})
-    response.raise_for_status()
-    return response.json()
-
-
-async def truncate_and_store_workouts(workouts: list[JSONType]):
+async def truncate_and_store_workouts(workouts: list) -> None:
     """Truncate the database and store new workouts.
 
     :param workouts: A list of workout data to store.
     """
-    async with Mongo_Conn("hevy_db") as db:
+    async with MongoConnection("hevy_db") as db:
         _log.info("Truncating and storing %d workouts", len(workouts))
         await db.workouts.drop()
         if workouts:

--- a/src/app/app.py
+++ b/src/app/app.py
@@ -9,9 +9,12 @@ _log = logging.getLogger(__name__)
 
 _hevy_api_repo = HevyApiRepository()
 
+
 async def pull_all_workouts(page_size: int = 5):
+    """Wrapper for pulling all workouts."""
     workouts = await _hevy_api_repo.pull_all_workouts(page_size=page_size)
     await truncate_and_store_workouts(workouts)
+
 
 async def truncate_and_store_workouts(workouts: list) -> None:
     """Truncate the database and store new workouts.

--- a/src/app/app.py
+++ b/src/app/app.py
@@ -4,6 +4,7 @@ import logging
 
 from app.db.conn import MongoConnection
 from app.db.data import HevyApiRepository
+from app.type import JSONType
 
 _log = logging.getLogger(__name__)
 
@@ -16,7 +17,7 @@ async def pull_all_workouts(page_size: int = 5):
     await truncate_and_store_workouts(workouts)
 
 
-async def truncate_and_store_workouts(workouts: list) -> None:
+async def truncate_and_store_workouts(workouts: list[JSONType]) -> None:
     """Truncate the database and store new workouts.
 
     :param workouts: A list of workout data to store.

--- a/src/app/db/conn.py
+++ b/src/app/db/conn.py
@@ -9,7 +9,7 @@ from app.config import settings
 _log = logging.getLogger(__name__)
 
 
-class Mongo_Conn:
+class MongoConnection:
     """MongoDB connection async context manager."""
 
     _connection_str = f"mongodb://{settings.mongodb.username}:{settings.mongodb.password}@{settings.mongodb.host}"

--- a/src/app/db/conn.py
+++ b/src/app/db/conn.py
@@ -14,7 +14,6 @@ class MongoConnection:
 
     _connection_str = f"mongodb://{settings.mongodb.username}:{settings.mongodb.password}@{settings.mongodb.host}"
 
-
     def __init__(self, db_name: str):
         """Initialize the database connection."""
         self._db_name = db_name

--- a/src/app/db/data.py
+++ b/src/app/db/data.py
@@ -1,5 +1,6 @@
 """Repositories for data access."""
 
+import asyncio
 import logging
 from abc import ABC
 from typing import TypeVar
@@ -13,7 +14,7 @@ _log = logging.getLogger(__name__)
 # JSONType is a recursive type hint for JSON-compatible data structures
 JSONType = TypeVar("None | bool | int | float | str | tuple | list | dict | JSONType")
 
-class RestfulApiRepository(ABC):
+class AbstractRestfulApiRepository(ABC):
     """Abstract base class for RESTful API repositories."""
     def __init__(self, base_url: str):
         """Initialize the repository with a base URL."""
@@ -30,10 +31,11 @@ class RestfulApiRepository(ABC):
         """Check if the repository is ready."""
         if self._session.is_closed:
             return False
-        response = self._session.get("/")
+        response = asyncio.run(self._session.get("/"))
         return response.status_code == 200
 
-class HevyApiRepository(RestfulApiRepository):
+
+class HevyApiRepository(AbstractRestfulApiRepository):
     """Repository for Hevy API."""
     _BASE_URL = f"{settings.hevy_api.url}/{settings.hevy_api.version}"
     _API_KEY = settings.hevy_api.key

--- a/src/app/db/data.py
+++ b/src/app/db/data.py
@@ -3,16 +3,13 @@
 import asyncio
 import logging
 from abc import ABC, abstractmethod
-from typing import TypeVar
 
 import httpx
 
 from app.config import settings
+from app.type import JSONType
 
 _log = logging.getLogger(__name__)
-
-# JSONType is a recursive type hint for JSON-compatible data structures
-JSONType = TypeVar("None | bool | int | float | str | tuple | list | dict | JSONType")
 
 
 class AbstractRestfulApiRepository(ABC):
@@ -24,7 +21,7 @@ class AbstractRestfulApiRepository(ABC):
         self._session = httpx.AsyncClient(base_url=self._base_url)
 
     @abstractmethod
-    async def get(self, endpoint: str) -> JSONType:
+    async def get(self, endpoint: str, params: dict) -> JSONType:
         """Get from the API."""
 
     @property
@@ -59,7 +56,7 @@ class HevyApiRepository(AbstractRestfulApiRepository):
         return response.json()
 
     # pull workouts with pagination
-    async def pull_all_workouts(self, page_size: int = 5) -> JSONType:
+    async def pull_all_workouts(self, page_size: int = 5) -> list[JSONType]:
         """Pull all workout data with pagination.
 
         :param page_size: The number of workouts to pull per page.

--- a/src/app/db/data.py
+++ b/src/app/db/data.py
@@ -1,0 +1,84 @@
+"""Repositories for data access."""
+
+import logging
+from abc import ABC
+from typing import TypeVar
+
+import httpx
+
+from app.config import settings
+
+_log = logging.getLogger(__name__)
+
+# JSONType is a recursive type hint for JSON-compatible data structures
+JSONType = TypeVar("None | bool | int | float | str | tuple | list | dict | JSONType")
+
+class RestfulApiRepository(ABC):
+    """Abstract base class for RESTful API repositories."""
+    def __init__(self, base_url: str):
+        """Initialize the repository with a base URL."""
+        self._base_url = base_url
+        self._session = httpx.AsyncClient(base_url=self._base_url)
+
+    @property
+    def base_url(self) -> str:
+        """Get the base URL of the repository."""
+        return self._base_url
+
+    @property
+    def is_ready(self) -> bool:
+        """Check if the repository is ready."""
+        if self._session.is_closed:
+            return False
+        response = self._session.get("/")
+        return response.status_code == 200
+
+class HevyApiRepository(RestfulApiRepository):
+    """Repository for Hevy API."""
+    _BASE_URL = f"{settings.hevy_api.url}/{settings.hevy_api.version}"
+    _API_KEY = settings.hevy_api.key
+    def __init__(self):
+        super().__init__(self._BASE_URL)
+        self._session.headers.update({"api-key": self._API_KEY})
+
+    # pull workouts with pagination
+    async def pull_all_workouts(self, page_size: int = 5) -> JSONType:
+        """Pull all workout data with pagination.
+
+        :param page_size: The number of workouts to pull per page.
+        """
+        workout_data = []
+        # page field is 1 indexed per:
+        # - https://api.hevyapp.com/docs/#/Workouts/PaginatedWorkoutEvents
+        current_page = 1
+
+        _log.info("Pulling all workouts with a page_size of %d", page_size)
+        # pull pages until len(pages) equils page_count field of json response
+        while True:
+            try:
+                data = await self._pull_workouts_page(current_page, page_size)
+            except httpx.HTTPError as e:
+                _log.error("Error pulling workouts: %s", e)
+                raise e
+            workouts = data.get("workouts", [])
+            workout_data.extend(workouts)
+            current_page += 1
+            # cover pagination cases
+            # - the events array is smaller than the page size
+            # - current_page is equal to page_count
+            if len(workouts) < page_size or data.get("page_count", 0) < data.get("page", 0):
+                break
+        _log.info("Finished pulling workouts at %d pages", current_page)
+        return workout_data
+
+
+    async def _pull_workouts_page(self, page: int, page_size: int) -> dict[JSONType]:
+        """Pull a single page of workout data.
+
+        :param page: The page number to pull.
+        :param page_size: The number of workouts to pull per page.
+        :return: The JSON response from the API.
+        """
+        response = await self._session.get("/workouts", params={"page": page, "pageSize": page_size})
+        response.raise_for_status()
+        return response.json()

--- a/src/app/type.py
+++ b/src/app/type.py
@@ -1,0 +1,6 @@
+"""Type definitions for the application."""
+
+type JSONPrimitive = None | bool | int | float | str
+type JSONArray[T] = list[JSONPrimitive | T | "JSONObject"]  # type: ignore
+type JSONObject[T] = dict[str, JSONPrimitive | JSONArray | T]  # type: ignore
+type JSONType[T] = T | JSONPrimitive | JSONArray | JSONObject

--- a/src/app/webhook.py
+++ b/src/app/webhook.py
@@ -25,7 +25,7 @@ async def webhook_post_handler(request: fastapi.Request):
 
 # optional AWS Lambda deployment package logic
 try:
-    from mangum import Mangum
+    from mangum import Mangum  # ty: ignore[unresolved-import]
 
     handler = Mangum(subscribe_app)
 except ImportError:

--- a/src/app/webhook.py
+++ b/src/app/webhook.py
@@ -1,0 +1,27 @@
+"""Listener for webhook subscriptions POST requests."""
+import logging
+
+import fastapi
+
+subscribe_app = fastapi.FastAPI()
+
+_log = logging.getLogger(__name__)
+
+@subscribe_app.get("/health")
+async def health_check():
+    """Health check endpoint."""
+    return {"status": "healthy"}
+
+@subscribe_app.post("/webhook")
+async def webhook_endpoint(request: fastapi.Request):
+    """Webhook endpoint."""
+    data = await request.json()
+    _log.info("Received webhook data: %s", data)
+    return {"status": "success"}
+
+# optional AWS Lambda deployment package logic
+try:
+    from mangum import Mangum
+    handler = Mangum(subscribe_app)
+except ImportError:
+    handler = None

--- a/src/app/webhook.py
+++ b/src/app/webhook.py
@@ -8,12 +8,12 @@ subscribe_app = fastapi.FastAPI()
 _log = logging.getLogger(__name__)
 
 @subscribe_app.get("/health")
-async def health_check():
+async def health_check_get_handler():
     """Health check endpoint."""
     return {"status": "healthy"}
 
 @subscribe_app.post("/webhook")
-async def webhook_endpoint(request: fastapi.Request):
+async def webhook_post_handler(request: fastapi.Request):
     """Webhook endpoint."""
     data = await request.json()
     _log.info("Received webhook data: %s", data)

--- a/src/app/webhook.py
+++ b/src/app/webhook.py
@@ -1,4 +1,5 @@
 """Listener for webhook subscriptions POST requests."""
+
 import logging
 
 import fastapi
@@ -7,10 +8,12 @@ subscribe_app = fastapi.FastAPI()
 
 _log = logging.getLogger(__name__)
 
+
 @subscribe_app.get("/health")
 async def health_check_get_handler():
     """Health check endpoint."""
     return {"status": "healthy"}
+
 
 @subscribe_app.post("/webhook")
 async def webhook_post_handler(request: fastapi.Request):
@@ -19,9 +22,11 @@ async def webhook_post_handler(request: fastapi.Request):
     _log.info("Received webhook data: %s", data)
     return {"status": "success"}
 
+
 # optional AWS Lambda deployment package logic
 try:
     from mangum import Mangum
+
     handler = Mangum(subscribe_app)
 except ImportError:
     handler = None

--- a/test/test_app.py
+++ b/test/test_app.py
@@ -5,7 +5,7 @@ from unittest import mock
 import httpx
 import pytest
 
-from app.app import _pull_workouts_page, pull_all_workouts, truncate_and_store_workouts
+from app.app import pull_all_workouts, truncate_and_store_workouts
 
 
 @pytest.mark.asyncio
@@ -34,7 +34,7 @@ async def test_pull_all_workouts():
     m_pull_workouts_page.side_effect = test_pull_workout_effect
     with (
         mock.patch("app.app.truncate_and_store_workouts", m_truncate_and_store),
-        mock.patch("app.app._pull_workouts_page", m_pull_workouts_page),
+        mock.patch("app.app._hevy_api_repo._pull_workouts_page", m_pull_workouts_page),
     ):
         await pull_all_workouts(page_size=m_page_size)
 
@@ -50,7 +50,7 @@ async def test_pull_all_workouts_http_error():
         raise httpx.HTTPError("HTTP error")
 
     m_pull_workouts_page = mock.AsyncMock(side_effect=test_pull_workout_effect)
-    with mock.patch("app.app._pull_workouts_page", m_pull_workouts_page):
+    with mock.patch("app.app._hevy_api_repo._pull_workouts_page", m_pull_workouts_page):
         with pytest.raises(httpx.HTTPError, match="HTTP error"):
             await pull_all_workouts()
 
@@ -59,7 +59,7 @@ async def test_pull_all_workouts_http_error():
 async def test_truncate_and_store_workouts():
     """Test truncating and storing workouts."""
     m_db = "hevy_db"
-    with mock.patch("app.app.Mongo_Conn") as m_conn:
+    with mock.patch("app.app.MongoConnection") as m_conn:
         m_conn.return_value = mock.AsyncMock()
         m_conn.return_value.__aenter__.return_value = m_conn.return_value
         await truncate_and_store_workouts([{"id": 1, "name": "Workout 1"}])
@@ -68,15 +68,3 @@ async def test_truncate_and_store_workouts():
             [{"id": 1, "name": "Workout 1"}]
         )
 
-
-@pytest.mark.asyncio
-async def test_pull_workouts_page():
-    """Test pulling a single page of workouts."""
-    with mock.patch("app.app.httpx.AsyncClient", new=mock.AsyncMock()) as m_client:
-        m_client.get.return_value.json.return_value = {
-            "workouts": [{"id": 1, "name": "Workout 1"}],
-            "page_size": 1,
-            "page_count": 1,
-            "page": 1,
-        }
-        await _pull_workouts_page(1, 1)

--- a/test/test_db_conn.py
+++ b/test/test_db_conn.py
@@ -2,12 +2,12 @@
 
 import pytest
 
-from app.conn import Mongo_Conn
+from app.db.conn import MongoConnection
 
 
 # test Mongo_Conn as a context manager
 @pytest.mark.asyncio
 async def test_mongo_conn():
     """Test MongoDB connection context manager."""
-    async with Mongo_Conn("test_db") as db:
+    async with MongoConnection("test_db") as db:
         assert db.name == "test_db"

--- a/test/test_db_data.py
+++ b/test/test_db_data.py
@@ -4,9 +4,29 @@ from unittest import mock
 
 import pytest
 
-from app.db.data import HevyApiRepository
+from app.db.data import HevyApiRepository, AbstractRestfulApiRepository
 
 
+@pytest.mark.parametrize(
+        "is_closed",
+        [True, False]
+)
+def test_abstract_repository_properties(is_closed):
+    m_url = "http://foo.bar/"
+    m_status_code = 200
+    with mock.patch("app.db.data.httpx.AsyncClient") as m_client:
+        m_client.return_value = mock.AsyncMock()
+        m_client.return_value.is_closed = is_closed
+
+        m_client_get_response = m_client.return_value.get.return_value = mock.AsyncMock()
+        m_client_get_response.status_code = m_status_code
+
+        m_repo = AbstractRestfulApiRepository(m_url)
+
+        assert m_repo.is_ready is not is_closed
+        assert m_repo.base_url == m_url
+
+## HevyApiRepository Tests
 class HevyApiTestRepository(HevyApiRepository):
     def __init__(self):
         super().__init__()
@@ -26,3 +46,6 @@ async def test_pull_workouts_page():
     }
 
     await m_repo._pull_workouts_page(1, 1)
+
+
+

--- a/test/test_db_data.py
+++ b/test/test_db_data.py
@@ -2,18 +2,37 @@
 
 from unittest import mock
 
+import httpx
 import pytest
 
-from app.db.data import HevyApiRepository, AbstractRestfulApiRepository
+from app.db.data import AbstractRestfulApiRepository, HevyApiRepository, JSONType
 
 
-@pytest.mark.parametrize(
-        "is_closed",
-        [True, False]
-)
+@pytest.fixture(scope="function", autouse=True)
+def httpx_client_fixture():
+    """Fixture for httpx.AsyncClient."""
+
+    def _httpx_client(status_code: int, content: JSONType):
+        test_client = httpx.AsyncClient(
+            transport=httpx.MockTransport(lambda request: httpx.Response(status_code, json=content)),
+            base_url="http://localhost/",
+        )
+        return test_client
+
+    return _httpx_client
+
+
+@pytest.mark.parametrize("is_closed", [True, False])
 def test_abstract_repository_properties(is_closed):
+    """Test the properties of the abstract repository."""
     m_url = "http://foo.bar/"
     m_status_code = 200
+
+    class TestRepository(AbstractRestfulApiRepository):
+        async def get(self, endpoint: str, params: dict) -> JSONType:
+            """Get from the API."""
+            return {"data": "test"}
+
     with mock.patch("app.db.data.httpx.AsyncClient") as m_client:
         m_client.return_value = mock.AsyncMock()
         m_client.return_value.is_closed = is_closed
@@ -21,31 +40,39 @@ def test_abstract_repository_properties(is_closed):
         m_client_get_response = m_client.return_value.get.return_value = mock.AsyncMock()
         m_client_get_response.status_code = m_status_code
 
-        m_repo = AbstractRestfulApiRepository(m_url)
+        m_repo = TestRepository(m_url)
 
         assert m_repo.is_ready is not is_closed
         assert m_repo.base_url == m_url
 
-## HevyApiRepository Tests
-class HevyApiTestRepository(HevyApiRepository):
-    def __init__(self):
-        super().__init__()
-        self._session = mock.AsyncMock()
-        self._session.get = mock.AsyncMock()
+
+@pytest.mark.parametrize(
+    "http_code, expected_response, except_expected",
+    [
+        (200, {"workouts": [{"id": 1, "name": "Workout 1"}]}, False),
+        (404, {"error": "Not Found"}, True),
+    ],
+)
+@pytest.mark.asyncio
+async def test_hevyrepository_pull_all_workouts(http_code, expected_response, except_expected, httpx_client_fixture):
+    """Test the pull_all_workouts method of the HevyApiRepository."""
+    m_repo = HevyApiRepository()
+    m_repo._session = httpx_client_fixture(status_code=http_code, content=expected_response)
+
+    if except_expected:
+        with pytest.raises(httpx.HTTPStatusError):
+            await m_repo.pull_all_workouts()
+    else:
+        response = await m_repo.pull_all_workouts()
+        assert response == expected_response["workouts"]
 
 
 @pytest.mark.asyncio
-async def test_pull_workouts_page():
-    """Test pulling a single page of workouts."""
-    m_repo = HevyApiTestRepository()
-    m_repo._session.get.return_value.json.return_value = {
-        "workouts": [{"id": 1, "name": "Workout 1"}],
-        "page_size": 1,
-        "page_count": 1,
-        "page": 1,
-    }
+async def test_hevyrepository_get(httpx_client_fixture):
+    """Test the get method of the HevyApiRepository."""
+    m_response = {"data": "test"}
+    m_repo = HevyApiRepository()
+    m_repo._session = httpx_client_fixture(status_code=200, content=m_response)
 
-    await m_repo._pull_workouts_page(1, 1)
-
-
-
+    response = await m_repo.get("/test-endpoint", params={"key": "value"})
+    assert response == {"data": "test"}

--- a/test/test_db_data.py
+++ b/test/test_db_data.py
@@ -1,0 +1,28 @@
+"""Tests for app.db.data module."""
+
+from unittest import mock
+
+import pytest
+
+from app.db.data import HevyApiRepository
+
+
+class HevyApiTestRepository(HevyApiRepository):
+    def __init__(self):
+        super().__init__()
+        self._session = mock.AsyncMock()
+        self._session.get = mock.AsyncMock()
+
+
+@pytest.mark.asyncio
+async def test_pull_workouts_page():
+    """Test pulling a single page of workouts."""
+    m_repo = HevyApiTestRepository()
+    m_repo._session.get.return_value.json.return_value = {
+        "workouts": [{"id": 1, "name": "Workout 1"}],
+        "page_size": 1,
+        "page_count": 1,
+        "page": 1,
+    }
+
+    await m_repo._pull_workouts_page(1, 1)

--- a/test/test_db_data.py
+++ b/test/test_db_data.py
@@ -5,7 +5,8 @@ from unittest import mock
 import httpx
 import pytest
 
-from app.db.data import AbstractRestfulApiRepository, HevyApiRepository, JSONType
+from app.db.data import AbstractRestfulApiRepository, HevyApiRepository
+from app.type import JSONType
 
 
 @pytest.fixture(scope="function", autouse=True)

--- a/test/test_intg_db_conn.py
+++ b/test/test_intg_db_conn.py
@@ -2,14 +2,14 @@
 
 import pytest
 
-from app.conn import Mongo_Conn
+from app.db.conn import MongoConnection
 
 
 @pytest.mark.integration
 @pytest.mark.asyncio
 async def test_mongo_conn():
     """Test MongoDB connection context manager."""
-    async with Mongo_Conn("test_db") as db:
+    async with MongoConnection("test_db") as db:
         try:
             await db.create_collection("test_collection")
             assert db.name == "test_db"

--- a/test/test_intg_webhook.py
+++ b/test/test_intg_webhook.py
@@ -1,0 +1,79 @@
+"""Integration tests for api client module."""
+import asyncio
+import socket
+import threading
+
+import httpx
+import pytest
+import uvicorn
+
+from app.webhook import subscribe_app
+
+pytestmark = [pytest.mark.integration]
+LOCAL_IP = "127.0.0.1"
+
+
+@pytest.fixture(scope="session", autouse=True)
+def socket_port_fixture():
+    """A fixture to create a socket port for the FastAPI server."""
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.bind(("localhost", 0))
+    port = sock.getsockname()[1]
+    sock.close()
+    return port
+
+@pytest.fixture(scope="session")
+def app_server_fixture(socket_port_fixture):
+    """A fixture to run a FastAPI server on a seperate thread."""
+    url = f"http://{LOCAL_IP}:{socket_port_fixture}"
+    config = uvicorn.Config(subscribe_app, host=LOCAL_IP, port=socket_port_fixture, log_level="info")
+    server = uvicorn.Server(config=config)
+
+    # we need a health check to prevent the url being yielded before the server
+    # has fully started
+    async def wait_for_health_check():
+        async with httpx.AsyncClient() as client:
+            while True:
+                try:
+                    response = await client.get(f"{url}/health")
+                    if response.status_code == 200:
+                        break
+                except httpx.HTTPError:
+                    pass
+                await asyncio.sleep(0.1)
+
+    server_thread = threading.Thread(target=asyncio.run, args=(server.serve(),))
+    server_thread.start()
+
+    asyncio.run(wait_for_health_check())
+
+    yield url
+
+    server.should_exit = True
+    server_thread.join()
+
+
+# A integration test that will send a post request to a endpoint
+# used to subscribe to a webhook and recieve a request with the
+# json body of:
+# ```json
+# {
+#   "id": "00000000-0000-0000-0000-000000000001",
+#   "payload": {
+#     "workoutId": "f1085cdb-32b2-4003-967d-53a3af8eaecb"
+#   }
+# } 
+# ```
+def test_webhook_endpoiont_recieves_data(app_server_fixture):
+    """Test that the webhook endpoint recieves data."""
+    data = {
+        "id": "00000000-0000-0000-0000-000000000001",
+        "payload": {
+            "workoutId": "f1085cdb-32b2-4003-967d-53a3af8eaecb"
+        }
+    }
+    url = f"{app_server_fixture}/webhook"
+
+    response = httpx.post(url, json=data)
+    assert response.status_code == 200
+    assert response.json() == {"status": "success"}

--- a/test/test_intg_webhook.py
+++ b/test/test_intg_webhook.py
@@ -1,4 +1,5 @@
 """Integration tests for api client module."""
+
 import asyncio
 import socket
 import threading
@@ -21,6 +22,7 @@ def socket_port_fixture():
     port = sock.getsockname()[1]
     sock.close()
     return port
+
 
 @pytest.fixture(scope="session")
 def app_server_fixture(socket_port_fixture):
@@ -62,15 +64,13 @@ def app_server_fixture(socket_port_fixture):
 #   "payload": {
 #     "workoutId": "f1085cdb-32b2-4003-967d-53a3af8eaecb"
 #   }
-# } 
+# }
 # ```
 def test_webhook_endpoiont_recieves_data(app_server_fixture):
     """Test that the webhook endpoint recieves data."""
     data = {
         "id": "00000000-0000-0000-0000-000000000001",
-        "payload": {
-            "workoutId": "f1085cdb-32b2-4003-967d-53a3af8eaecb"
-        }
+        "payload": {"workoutId": "f1085cdb-32b2-4003-967d-53a3af8eaecb"},
     }
     url = f"{app_server_fixture}/webhook"
 

--- a/test/test_intg_webhook.py
+++ b/test/test_intg_webhook.py
@@ -26,7 +26,7 @@ def socket_port_fixture():
 
 @pytest.fixture(scope="session")
 def app_server_fixture(socket_port_fixture):
-    """A fixture to run a FastAPI server on a seperate thread."""
+    """A fixture to run a FastAPI server on a separate thread."""
     url = f"http://{LOCAL_IP}:{socket_port_fixture}"
     config = uvicorn.Config(subscribe_app, host=LOCAL_IP, port=socket_port_fixture, log_level="info")
     server = uvicorn.Server(config=config)

--- a/test/test_intg_webhook.py
+++ b/test/test_intg_webhook.py
@@ -66,8 +66,8 @@ def app_server_fixture(socket_port_fixture):
 #   }
 # }
 # ```
-def test_webhook_endpoiont_recieves_data(app_server_fixture):
-    """Test that the webhook endpoint recieves data."""
+def test_webhook_endpoint_receives_data(app_server_fixture):
+    """Test that the webhook endpoint receives data."""
     data = {
         "id": "00000000-0000-0000-0000-000000000001",
         "payload": {"workoutId": "f1085cdb-32b2-4003-967d-53a3af8eaecb"},

--- a/test/test_webhook.py
+++ b/test/test_webhook.py
@@ -1,9 +1,10 @@
 """Unit tests for webook module."""
 
-from fastapi.testclient import TestClient
 import pytest
+from fastapi.testclient import TestClient
 
-from app.webhook import webhook_post_handler, health_check_get_handler, subscribe_app
+from app.webhook import subscribe_app
+
 
 @pytest.fixture
 def client_fixture():
@@ -11,11 +12,13 @@ def client_fixture():
     with TestClient(subscribe_app) as c:
         yield c
 
+
 def test_health_check(client_fixture):
     """Test health check endpoint."""
     response = client_fixture.get("/health")
     assert response.status_code == 200
     assert response.json() == {"status": "healthy"}
+
 
 def test_webhook(client_fixture):
     """Test webhook endpoint."""

--- a/test/test_webhook.py
+++ b/test/test_webhook.py
@@ -1,4 +1,4 @@
-"""Unit tests for webook module."""
+"""Unit tests for app.webhook module."""
 
 import pytest
 from fastapi.testclient import TestClient

--- a/test/test_webhook.py
+++ b/test/test_webhook.py
@@ -1,0 +1,24 @@
+"""Unit tests for webook module."""
+
+from fastapi.testclient import TestClient
+import pytest
+
+from app.webhook import webhook_post_handler, health_check_get_handler, subscribe_app
+
+@pytest.fixture
+def client_fixture():
+    """A test client for the webhook app."""
+    with TestClient(subscribe_app) as c:
+        yield c
+
+def test_health_check(client_fixture):
+    """Test health check endpoint."""
+    response = client_fixture.get("/health")
+    assert response.status_code == 200
+    assert response.json() == {"status": "healthy"}
+
+def test_webhook(client_fixture):
+    """Test webhook endpoint."""
+    response = client_fixture.post("/webhook", json={"key": "value"})
+    assert response.status_code == 200
+    assert response.json() == {"status": "success"}


### PR DESCRIPTION
As a software engineer I need to be able to be able to have a endpoint for webhook subscriptions for the hevy API.

# Changes

- move data logic from the api to a repository
- added a webhook fastapi application to act as a subscription endpoint for webhook subscriptions
- webhook fastapi has a healthcheck endpoint

# Test
- Added integration tests to test fastapi endpoint
- update and added unit tests
- rewrote unit test that use httpx  to use the mock transport suggested by httpx documentation

# Out of Scope
- the fastapi application is not deployed current with the __main__ module and will be addressed later

# Note

The syntax for a recursive type hint is the 3.12+ PEP 595 syntax:
```python
type GenericHolder[T] = list[str | int | T]
```

Ignore the `async.run` in the `is_ready` property of app.db.data::AbstractRestfulRepository during review, it is a no-fix.