### PR TITLE
Add Terraform deployment for webhook on AWS Lambda + API Gateway

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 A Python-based utility for:
 
 - pulling workout and exercise data from the [Hevy][hevy_app] fitness app API.
-- Keeping that data up to date with a webhook subscription and deployment to Google App Engine. (in-progress)
+- Keeping that data up to date with a webhook subscription, deployed to AWS Lambda + API Gateway with Terraform.
 
 It is designed for personal analysis, backups, or integration into custom dashboards and data platforms.
 
@@ -85,6 +85,22 @@ There are three different type of configuration files used in this project
     username: admin
     host: "localhost:27017"
     ```
+
+## Deployment (AWS)
+
+The webhook component deploys to AWS as a Lambda function (FastAPI via
+[Mangum](https://mangum.fastapiexpert.com/)) behind an API Gateway HTTP API,
+managed with Terraform:
+
+```bash
+cd terraform
+terraform init
+terraform apply
+echo "$(terraform output -raw webhook_api_endpoint)/webhook"
+```
+
+See [terraform/README.md](terraform/README.md) for architecture details,
+prerequisites, and configuration variables.
 
 ## Development
 

--- a/terraform/.gitignore
+++ b/terraform/.gitignore
@@ -1,0 +1,11 @@
+# Terraform state and workspace files
+.terraform/
+*.tfstate
+*.tfstate.*
+*.tfvars
+*.tfvars.json
+crash.log
+crash.*.log
+
+# Lambda build artifacts
+build/

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -1,0 +1,61 @@
+# AWS Webhook Infrastructure
+
+Terraform configuration that deploys the webhook component (`app.webhook`)
+to AWS as a Lambda function fronted by an API Gateway HTTP API.
+
+## Architecture
+
+```
+Hevy webhook ──> API Gateway (HTTP API) ──> Lambda (FastAPI via Mangum) ──> CloudWatch Logs
+                   POST /webhook
+                   GET  /health
+```
+
+- **Lambda** runs the FastAPI app in `src/app/webhook.py` through the
+  [Mangum](https://mangum.fastapiexpert.com/) ASGI adapter
+  (handler: `app.webhook.handler`, runtime: `python3.12`).
+- **API Gateway v2 (HTTP API)** routes `POST /webhook` and `GET /health`
+  to the Lambda with a payload format 2.0 proxy integration.
+- **CloudWatch** log groups capture Lambda logs and API access logs.
+
+The deployment package is built by `scripts/build_lambda_package.sh`,
+which installs the Lambda-only dependencies (`terraform/lambda/requirements.txt`)
+for the Lambda runtime platform and copies in `src/app` and `config/`.
+Terraform triggers a rebuild automatically whenever the app source,
+config, or requirements change.
+
+## Prerequisites
+
+- Terraform >= 1.6
+- Python 3 with `pip` (used to build the Lambda package)
+- AWS credentials with permission to manage Lambda, API Gateway, IAM,
+  and CloudWatch resources (e.g. via `AWS_PROFILE`)
+
+## Usage
+
+```bash
+cd terraform
+terraform init
+terraform plan
+terraform apply
+```
+
+The webhook subscription URL to register with the Hevy API is:
+
+```bash
+echo "$(terraform output -raw webhook_api_endpoint)/webhook"
+```
+
+## Variables
+
+| Variable | Default | Purpose |
+| -------- | ------- | ------- |
+| `aws_region` | `us-west-2` | Deployment region |
+| `project_name` | `hevy-api-pull` | Resource name prefix |
+| `app_environment` | `prod` | Value of the `ENV` variable in the Lambda (selects the dynaconf config file) |
+| `lambda_memory_size` | `256` | Lambda memory (MB) |
+| `lambda_timeout` | `10` | Lambda timeout (seconds) |
+| `log_retention_days` | `30` | CloudWatch retention for both log groups |
+
+State is local by default; add a `backend` block in `versions.tf` if you
+want remote state (e.g. S3).

--- a/terraform/api_gateway.tf
+++ b/terraform/api_gateway.tf
@@ -1,0 +1,55 @@
+resource "aws_apigatewayv2_api" "webhook" {
+  name          = "${local.name_prefix}-webhook"
+  protocol_type = "HTTP"
+}
+
+resource "aws_cloudwatch_log_group" "api_access" {
+  name              = "/aws/apigateway/${local.name_prefix}-webhook"
+  retention_in_days = var.log_retention_days
+}
+
+resource "aws_apigatewayv2_stage" "default" {
+  api_id      = aws_apigatewayv2_api.webhook.id
+  name        = "$default"
+  auto_deploy = true
+
+  access_log_settings {
+    destination_arn = aws_cloudwatch_log_group.api_access.arn
+    format = jsonencode({
+      requestId      = "$context.requestId"
+      httpMethod     = "$context.httpMethod"
+      path           = "$context.path"
+      status         = "$context.status"
+      responseLength = "$context.responseLength"
+      requestTime    = "$context.requestTime"
+      sourceIp       = "$context.identity.sourceIp"
+    })
+  }
+}
+
+resource "aws_apigatewayv2_integration" "webhook_lambda" {
+  api_id                 = aws_apigatewayv2_api.webhook.id
+  integration_type       = "AWS_PROXY"
+  integration_uri        = aws_lambda_function.webhook.invoke_arn
+  payload_format_version = "2.0"
+}
+
+resource "aws_apigatewayv2_route" "health" {
+  api_id    = aws_apigatewayv2_api.webhook.id
+  route_key = "GET /health"
+  target    = "integrations/${aws_apigatewayv2_integration.webhook_lambda.id}"
+}
+
+resource "aws_apigatewayv2_route" "webhook" {
+  api_id    = aws_apigatewayv2_api.webhook.id
+  route_key = "POST /webhook"
+  target    = "integrations/${aws_apigatewayv2_integration.webhook_lambda.id}"
+}
+
+resource "aws_lambda_permission" "api_gateway" {
+  statement_id  = "AllowAPIGatewayInvoke"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.webhook.function_name
+  principal     = "apigateway.amazonaws.com"
+  source_arn    = "${aws_apigatewayv2_api.webhook.execution_arn}/*/*"
+}

--- a/terraform/lambda.tf
+++ b/terraform/lambda.tf
@@ -1,0 +1,68 @@
+# Build the Lambda deployment package (dependencies + app source) whenever
+# the source hash changes.
+resource "null_resource" "lambda_build" {
+  triggers = {
+    source_hash = local.lambda_source_hash
+  }
+
+  provisioner "local-exec" {
+    command = "${path.module}/scripts/build_lambda_package.sh"
+  }
+}
+
+data "archive_file" "webhook_lambda" {
+  type        = "zip"
+  source_dir  = "${path.module}/build/package"
+  output_path = "${path.module}/build/webhook_lambda.zip"
+
+  depends_on = [null_resource.lambda_build]
+}
+
+resource "aws_iam_role" "webhook_lambda" {
+  name = "${local.name_prefix}-webhook-lambda"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect    = "Allow"
+      Action    = "sts:AssumeRole"
+      Principal = { Service = "lambda.amazonaws.com" }
+    }]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "webhook_lambda_logs" {
+  role       = aws_iam_role.webhook_lambda.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+}
+
+resource "aws_cloudwatch_log_group" "webhook_lambda" {
+  name              = "/aws/lambda/${local.name_prefix}-webhook"
+  retention_in_days = var.log_retention_days
+}
+
+resource "aws_lambda_function" "webhook" {
+  function_name = "${local.name_prefix}-webhook"
+  role          = aws_iam_role.webhook_lambda.arn
+
+  filename         = data.archive_file.webhook_lambda.output_path
+  source_code_hash = data.archive_file.webhook_lambda.output_base64sha256
+
+  runtime       = "python3.12"
+  architectures = ["x86_64"]
+  handler       = "app.webhook.handler"
+
+  memory_size = var.lambda_memory_size
+  timeout     = var.lambda_timeout
+
+  environment {
+    variables = {
+      ENV = var.app_environment
+    }
+  }
+
+  depends_on = [
+    aws_iam_role_policy_attachment.webhook_lambda_logs,
+    aws_cloudwatch_log_group.webhook_lambda,
+  ]
+}

--- a/terraform/lambda/requirements.txt
+++ b/terraform/lambda/requirements.txt
@@ -1,0 +1,6 @@
+# Dependencies for the webhook Lambda deployment package.
+# The webhook component (app.webhook) only needs the ASGI app and the
+# Lambda adapter; the batch-job dependencies (pymongo, httpx, dynaconf)
+# are intentionally excluded to keep the package small.
+fastapi
+mangum

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,27 @@
+provider "aws" {
+  region = var.aws_region
+
+  default_tags {
+    tags = {
+      Project     = var.project_name
+      Environment = var.app_environment
+      ManagedBy   = "terraform"
+    }
+  }
+}
+
+locals {
+  repo_root   = abspath("${path.module}/..")
+  name_prefix = "${var.project_name}-${var.app_environment}"
+
+  # Hash of everything that goes into the Lambda package, used to
+  # trigger a rebuild when the source or dependencies change.
+  lambda_source_hash = sha256(join("", concat(
+    [for f in sort(fileset("${local.repo_root}/src/app", "**")) : filesha256("${local.repo_root}/src/app/${f}")],
+    [for f in sort(fileset("${local.repo_root}/config", "*.yaml")) : filesha256("${local.repo_root}/config/${f}")],
+    [
+      filesha256("${path.module}/lambda/requirements.txt"),
+      filesha256("${path.module}/scripts/build_lambda_package.sh"),
+    ],
+  )))
+}

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,0 +1,14 @@
+output "webhook_api_endpoint" {
+  description = "Base URL of the webhook HTTP API. The webhook subscription URL is <endpoint>/webhook."
+  value       = aws_apigatewayv2_api.webhook.api_endpoint
+}
+
+output "webhook_lambda_function_name" {
+  description = "Name of the webhook Lambda function."
+  value       = aws_lambda_function.webhook.function_name
+}
+
+output "webhook_lambda_log_group" {
+  description = "CloudWatch log group for the webhook Lambda function."
+  value       = aws_cloudwatch_log_group.webhook_lambda.name
+}

--- a/terraform/scripts/build_lambda_package.sh
+++ b/terraform/scripts/build_lambda_package.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Builds the AWS Lambda deployment package for the webhook component.
+#
+# Installs the Lambda runtime dependencies (built for the Lambda
+# python3.12 x86_64 runtime) and copies the application source and
+# configuration into terraform/build/package, which Terraform then zips.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TF_DIR="$(dirname "$SCRIPT_DIR")"
+REPO_ROOT="$(dirname "$TF_DIR")"
+PACKAGE_DIR="$TF_DIR/build/package"
+
+LAMBDA_PYTHON_VERSION="${LAMBDA_PYTHON_VERSION:-3.12}"
+
+rm -rf "$PACKAGE_DIR"
+mkdir -p "$PACKAGE_DIR"
+
+python3 -m pip install \
+  --quiet \
+  --target "$PACKAGE_DIR" \
+  --platform manylinux2014_x86_64 \
+  --implementation cp \
+  --python-version "$LAMBDA_PYTHON_VERSION" \
+  --only-binary=:all: \
+  --requirement "$TF_DIR/lambda/requirements.txt"
+
+cp -r "$REPO_ROOT/src/app" "$PACKAGE_DIR/app"
+cp -r "$REPO_ROOT/config" "$PACKAGE_DIR/config"
+
+# remove caches and secrets so the archive is stable and clean
+find "$PACKAGE_DIR" -type d -name '__pycache__' -prune -exec rm -rf {} +
+rm -f "$PACKAGE_DIR"/config/.secrets.yaml
+
+echo "Lambda package built at $PACKAGE_DIR"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,35 @@
+variable "aws_region" {
+  description = "AWS region to deploy the webhook infrastructure into."
+  type        = string
+  default     = "us-west-2"
+}
+
+variable "project_name" {
+  description = "Name used to prefix all created resources."
+  type        = string
+  default     = "hevy-api-pull"
+}
+
+variable "app_environment" {
+  description = "Application environment passed to the app as the ENV variable (selects the dynaconf config file)."
+  type        = string
+  default     = "prod"
+}
+
+variable "lambda_memory_size" {
+  description = "Memory (MB) allocated to the webhook Lambda function."
+  type        = number
+  default     = 256
+}
+
+variable "lambda_timeout" {
+  description = "Timeout (seconds) for the webhook Lambda function."
+  type        = number
+  default     = 10
+}
+
+variable "log_retention_days" {
+  description = "CloudWatch log retention for the Lambda and API Gateway access logs."
+  type        = number
+  default     = 30
+}

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -1,0 +1,18 @@
+terraform {
+  required_version = ">= 1.6"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+    archive = {
+      source  = "hashicorp/archive"
+      version = "~> 2.4"
+    }
+    null = {
+      source  = "hashicorp/null"
+      version = "~> 3.2"
+    }
+  }
+}


### PR DESCRIPTION
Deploy the FastAPI webhook component (app.webhook, via its existing
Mangum handler) as a Lambda function behind an API Gateway HTTP API:

- terraform/: Lambda function, IAM role, API Gateway v2 routes for
  POST /webhook and GET /health, and CloudWatch log groups
- terraform/scripts/build_lambda_package.sh: builds the deployment
  package with Lambda-runtime wheels (fastapi + mangum only) plus the
  app source and config; Terraform rebuilds it on source changes
- README updated to document AWS deployment (replaces the planned
  Google App Engine deployment)

https://claude.ai/code/session_01QoXYjCusLUm1jDj3G8CPh8